### PR TITLE
:tv: allow openapi compatible llm endpoints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,9 @@ If you wish to use a different model from OpenAI or Anthropic, add it on the com
 You will need to include an API key for the LLM. This can be ``OPENAI_API_KEY`` for an OpenAI LLM or ``ANTHROPIC_API_KEY`` for Anthropic.
 You can also pass the API key to hespi with the ``--llm-api-key API_KEY`` argument.
 
+For OpenAPI compatible endpoints (such as OpenRouter), you can specify the base URL with the ``--llm-base-url BASE_URL`` argument.
+For example, to use OpenRouter, you would use: ``--llm-base-url https://openrouter.ai/api/v1``
+
 More information on the command line arguments can be found in the `Command Line Reference <https://rbturnbull.github.io/hespi/cli.html>`_ in the documentation.
 
 There is another command line utility called ``hespi-tools`` which provides additional functionality.

--- a/hespi/hespi.py
+++ b/hespi/hespi.py
@@ -44,6 +44,7 @@ class Hespi():
         htr: bool = True,
         llm_model: str = "gpt-4o",
         llm_api_key: str = "",
+        llm_base_url: str = "",
         llm_temperature: float = 0.0,
         batch_size:int = 4,
         sheet_component_res:int = 1280,
@@ -62,7 +63,7 @@ class Hespi():
         self.label_field_res = label_field_res
 
         if llm_model and llm_model.lower() != "none":
-            self.llm = get_llm(llm_model, llm_api_key, llm_temperature)
+            self.llm = get_llm(llm_model, llm_api_key, llm_base_url, llm_temperature)
         else:
             self.llm = None
         

--- a/hespi/llm.py
+++ b/hespi/llm.py
@@ -113,13 +113,16 @@ def output_parser(text:str) -> dict[str, str]:
 def get_llm(
     model_id:str="gpt-4o",
     api_key:str="",
+    base_url:str="",
     temperature:float=0.0,
 ) -> BaseChatModel:
-    if model_id.startswith('gpt'):
+    # Handle OpenAI and OpenAPI compatible models (including OpenRouter)
+    if model_id.startswith('gpt') or base_url:
         return ChatOpenAI(
-            openai_api_key=api_key, 
+            openai_api_key=api_key,
             temperature=temperature,
             model_name=model_id,
+            base_url=base_url if base_url else None,
         )
     
     if model_id.startswith('claude'):

--- a/hespi/main.py
+++ b/hespi/main.py
@@ -32,11 +32,15 @@ def detect(
     ),
     llm: str = typer.Option(
         "gpt-4o",
-        help="The Large Langauge Model to use. Currently OpenAI and Anthropic Claude models supported.",
+        help="The Large Language Model to use. Currently OpenAI, Anthropic Claude, and OpenAPI compatible models are supported. For OpenAPI compatible models, also specify --llm-base-url.",
     ),
     llm_api_key: str = typer.Option(
         "",
         help="The API key to use for the Large Language Model. Can be set as an environment variable using the standard variable names.",
+    ),
+    llm_base_url: str = typer.Option(
+        "",
+        help="The base URL for OpenAPI compatible endpoints (e.g., OpenRouter). Use this for models hosted on OpenRouter or other OpenAPI compatible services.",
     ),
     llm_temperature: float = typer.Option(
         0.0,
@@ -85,6 +89,7 @@ def detect(
         fuzzy_cutoff=fuzzy_cutoff,
         llm_model=llm,
         llm_api_key=llm_api_key,
+        llm_base_url=llm_base_url,
         llm_temperature=llm_temperature,
         htr=htr,
         batch_size=batch_size,

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -104,6 +104,13 @@ def test_get_llm_error():
 
 
 @patch("hespi.llm.ChatOpenAI", mock_llm)
+def test_get_llm_openapi():
+    # Test that OpenAPI compatible models work with base_url
+    llm = get_llm("openai-model", "test-key", "https://api.openrouter.ai/api/v1")
+    assert llm is not None
+
+
+@patch("hespi.llm.ChatOpenAI", mock_llm)
 def test_llm():
     primary_specimen_label_image = test_data_dir/"institution_label.jpg"
     detection_results = {


### PR DESCRIPTION
Hello HESPI team,
we've started experimenting with the model to integrate it into our herbarium specimen photo repository. Very soon, we ran into a limitation: there was no flexible way to call LLMs using OpenRouter or other compatible providers.

To address this, we propose adding a new configuration option: llm-base-url.